### PR TITLE
Send the query patch to the IssueQuery class if it exists (#37)

### DIFF
--- a/lib/tagging_plugin/tagging_query_patch.rb
+++ b/lib/tagging_plugin/tagging_query_patch.rb
@@ -102,5 +102,5 @@ else
   Query
 end
 
-klass.send(:include, TaggingPlugin::QueryPatch) unless Query.included_modules.include? TaggingPlugin::QueryPatch
+klass.send(:include, TaggingPlugin::QueryPatch) unless klass.included_modules.include? TaggingPlugin::QueryPatch
 QueriesHelper.send(:include, TaggingPlugin::QueriesHelperPatch) unless QueriesHelper.included_modules.include? TaggingPlugin::QueriesHelperPatch

--- a/lib/tagging_plugin/tagging_query_patch.rb
+++ b/lib/tagging_plugin/tagging_query_patch.rb
@@ -96,5 +96,11 @@ module TaggingPlugin
 
 end
 
-Query.send(:include, TaggingPlugin::QueryPatch) unless Query.included_modules.include? TaggingPlugin::QueryPatch
+klass = if require_dependency 'issue_query'
+  IssueQuery
+else
+  Query
+end
+
+klass.send(:include, TaggingPlugin::QueryPatch) unless Query.included_modules.include? TaggingPlugin::QueryPatch
 QueriesHelper.send(:include, TaggingPlugin::QueriesHelperPatch) unless QueriesHelper.included_modules.include? TaggingPlugin::QueriesHelperPatch


### PR DESCRIPTION
This should address the failures in the latest Redmine 2.2 master