### PR TITLE
Fix search in Redmine 3.2.1

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -15,7 +15,7 @@ ActionDispatch::Callbacks.to_prepare do
     Issue.searchable_options[:include] << :issue_tags
 
     # For redmine > 3
-    Issue.searchable_options[:scope] = -> { Issue.includes(:issue_tags) }
+    Issue.searchable_options[:scope] = proc { Issue.includes(:issue_tags) }
   end
 
   unless WikiPage.searchable_options[:include] && WikiPage.searchable_options[:include].include?(:wiki_page_tags)
@@ -26,7 +26,7 @@ ActionDispatch::Callbacks.to_prepare do
     WikiPage.searchable_options[:include] << :wiki_page_tags
 
     # For redmine > 3
-    WikiPage.searchable_options[:scope] = -> { WikiPage.includes(:wiki_page_tags) }
+    WikiPage.searchable_options[:scope] = proc { WikiPage.includes(:wiki_page_tags) }
   end
 end
 


### PR DESCRIPTION
Scope lambdas in search are passed an `options` argument, but lambdas defined
in `init.rb` don't accept any arguments. Since they are lambdas, the arguments
are validated at runtime and it fails with exception. Simply changing them to
`proc`s fixes the issue.

Related line from Redmine: https://github.com/redmine/redmine/blob/fcb4e510ea3c4de06aa7dfad31c772ad589fd612/lib/plugins/acts_as_searchable/lib/acts_as_searchable.rb#L186